### PR TITLE
Include $Server in $Splat to enable using -Server

### DIFF
--- a/DomainHealthChecker.psm1
+++ b/DomainHealthChecker.psm1
@@ -48,10 +48,16 @@ function Invoke-SpfDkimDmarc {
                     'DkimSelector' = $DkimSelector
                 }
             }
+            
+            if ($Server) {
+                $Splat += @{
+                    'Server' = $Server
+                }
+            }
 
-            $SPF = Get-SPFRecord -Name $Name
+            $SPF = Get-SPFRecord -Name $Name @Splat
             $DKIM = Get-DKIMRecord -Name $Name @Splat
-            $DMARC = Get-DMARCRecord -Name $Name
+            $DMARC = Get-DMARCRecord -Name $Name @Splat
 
             $InvokeReturnValues = New-Object psobject
             $InvokeReturnValues | Add-Member NoteProperty "Name" $SPF.Name


### PR DESCRIPTION
When running Invoke-SpfDkimDmarc with -Server specified as anything the server is not provided to any function. Whatever DNS server is configured on the computer running the script will be used, this causes issues in split-brain scenarioes where the internal DNS is different from the external. 

I've included the specified server in $Splat and provided that to Get-SPFRecord and Get-DMARCRecord. Get-DKIMRecord is already provided this due to the selector. 