### PR TITLE
Fixes for custom DkimSelector and Server

### DIFF
--- a/DomainHealthChecker.psm1
+++ b/DomainHealthChecker.psm1
@@ -42,15 +42,13 @@ function Invoke-SpfDkimDmarc {
     begin {
         $InvokeObject = New-Object System.Collections.Generic.List[System.Object]        
     } process {
-        function StartDomainHealthCheck($Name, $DkimSelector) {
+        function StartDomainHealthCheck($Name) {
             if ($DkimSelector -or $Server) {
                 $Splat = @{
                     'DkimSelector' = $DkimSelector
                     'Server' = $Server
                 }
             }
-
-            Write-Host @Splat
 
             $SPF = Get-SPFRecord -Name $Name @Splat
             $DKIM = Get-DKIMRecord -Name $Name @Splat

--- a/DomainHealthChecker.psm1
+++ b/DomainHealthChecker.psm1
@@ -48,10 +48,16 @@ function Invoke-SpfDkimDmarc {
                     'DkimSelector' = $DkimSelector
                 }
             }
+            
+            if ($Server) {
+                $Splat += @{
+                    'Server' = $Server
+                }
+            }
 
-            $SPF = Get-SPFRecord -Name $Name
+            $SPF = Get-SPFRecord -Name $Name @Splat
             $DKIM = Get-DKIMRecord -Name $Name @Splat
-            $DMARC = Get-DMARCRecord -Name $Name
+            $DMARC = Get-DMARCRecord -Name $Name @Splat
 
             $InvokeReturnValues = New-Object psobject
             $InvokeReturnValues | Add-Member NoteProperty "Name" $SPF.Name

--- a/DomainHealthChecker.psm1
+++ b/DomainHealthChecker.psm1
@@ -43,17 +43,14 @@ function Invoke-SpfDkimDmarc {
         $InvokeObject = New-Object System.Collections.Generic.List[System.Object]        
     } process {
         function StartDomainHealthCheck($Name, $DkimSelector) {
-            if ($DkimSelector) {
+            if ($DkimSelector -or $Server) {
                 $Splat = @{
                     'DkimSelector' = $DkimSelector
-                }
-            }
-            
-            if ($Server) {
-                $Splat += @{
                     'Server' = $Server
                 }
             }
+
+            Write-Host @Splat
 
             $SPF = Get-SPFRecord -Name $Name @Splat
             $DKIM = Get-DKIMRecord -Name $Name @Splat

--- a/public/Get-DMARCRecord.ps1
+++ b/public/Get-DMARCRecord.ps1
@@ -13,7 +13,10 @@ function Get-DMARCRecord {
 
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.")]
-        [string]$Server
+        [string]$Server,
+
+        [Parameter(Mandatory = $false)]
+        [string]$DkimSelector = $null
     )
 
     begin {

--- a/public/Get-SPFRecord.ps1
+++ b/public/Get-SPFRecord.ps1
@@ -13,7 +13,10 @@ function Get-SPFRecord {
 
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.")]
-        [string]$Server
+        [string]$Server,
+
+        [Parameter(Mandatory = $false)]
+        [string]$DkimSelector = $null
     )
 
     begin {


### PR DESCRIPTION
Sorry for the multiple pull requests. 

Specifying -Server and/or -DkimSelector does not work as intended. They are not always provided to functions. For -Server it is never provided to any function and any query will run against whatever DNS server is configured where the code is running.

I've included the specified server in $Splat and provided that to Get-SPFRecord and Get-DMARCRecord. Get-DKIMRecord is already provided this due to the selector. Since $Splat also might include DkimSelector for both Get-SPFRecord and Get-DMARCRecord I've had to include this as an allowed argument for the functions. Its kinda ugly since the arguments will never be used but does not require changing $Splat any more.
