### PR TITLE
Update to version 2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ All notable updates on the module will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-[2.1] - 23-1-2026
+[2.1] - 28-1-2026
 
 - Added `-SkipUpdateCheck` on calling the module, to skip the update check against the PowerShellgallery
 - Added `Get-BIMIRecord` check, this function resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ All notable updates on the module will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-[2.1] - X-X-2026
+[2.1] - 23-1-2026
 
 - Added `-SkipUpdateCheck` on calling the module, to skip the update check against the PowerShellgallery
 - Added `Get-BIMIRecord` check, this function resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,13 +6,25 @@ All notable updates on the module will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+[2.1] - X-X-2026
+
+- Added `-SkipUpdateCheck` on calling the module, to skip the update check against the PowerShellgallery
+- Added `Get-BIMIRecord` check, this function resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.
+
+### Changed
+- Renamed `Update-ModuleVersion` to `Update-DomainHealthChecker` to better reflect the true mean of this function.
+- Updated README/help docs
+
+### Removed
+- Removed the `-IncludeDNSSEC` parameter, DNSSEC is now default queried
+
 [2.0] - 7-1-2026
 
 ### Added
 - Added cross-platform support for macOS and Linux with PowerShell Core. (#39)
 - Added `Get-OsPlatform.ps1` for OS determining.
 - Added `Test-DnsUtilsInstalled.ps1` for checking if DNS utilities for `dig` is installed.
-- Added `Update-ModuleVersion.ps1` for automatic module version updating.
+- Added `Update-ModuleDomainHealthChecker.ps1` for automatic module version updating.
 
 ### Changed
 - Updated README/help docs
@@ -29,21 +41,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Error when no SPFrecords are present (#48)
 
 [1.7] - 9-11-2024
-### Added:
+### Added
 - New function `Get-MTASTS`. (#41)
 - Added support for multiple values for the `-Name` parameter. (#43)
 
-### Updated:
+### Updated
 - Default DKIM-selectors.
 
-### Fixed:
+### Fixed
 - DkimSelector not working for Invoke-SpfDkimDmarc (#37).
 - Typo in SPF Length (#38 #42).
 - SPF check not correct (#44).
 - SPF Length (#45).
 - DkimSelector not working for Invoke-SpfDkimDmarc (#37).
 
-### Changed:
+### Changed
 - Updated the Readme/help docs (#40)
 
 ## New Contributors
@@ -59,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Get-SPFRecord.ps1 bug - SPF record that over 255 characters bug in #31
 - Invoke-SpfDkimDmarc not using -server property bug in #32 
 
-## New Contributors
+### New Contributors
 - @mortenmw made their first contribution in https://github.com/T13nn3s/Invoke-SpfDkimDmarc/pull/30
 
 [1.5.2] - 30-2-2022
@@ -80,20 +92,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Added new exported function Get-SPFRecord.
 - Added new exported function Get-DKIMRecord.
 - Added new exported function Get-DMARCRecord.
-- Added alias `Show-SpfDkimDmarc` for `Invoke-SpfDkimDmarc`.
+- Added alias `Invoke-SpfDkimDmarc` for `Invoke-SpfDkimDmarc`.
 - Added alias `gspf` for `Get-SPFRecord`. 
 - Added alias `gdkim` for `Get-DKIMRecord`.
 - Added alias `gdmarc` for `Get-DMARCRecord`.
 
 ### Changed
-- Removed cmdlet `Show-SpfDkimDmarc`. Use `Invoke-SpfDkimDmarc`
 - Each function has his own PowerShell script file.
+
+### Removed
+- Removed cmdlet `Show-SpfDkimDmarc`. Use `Invoke-SpfDkimDmarc`
 
 [1.4.2] - 2021-07-13
 ### Added
 - More commonly used DKIM-selectors to the default DKIM check.
 
-### Changed
+### Removed
 - Removed hardcoded DNS. You need to specify it manually.
 
 [1.4.1] - 2021-07-07
@@ -108,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 - Multiple if/elseif statements replaced with switches.
-- Turn Script into a Module with proper verb/noun Show-SpfDkimDmarc.
+- Turn Script into a Module with proper verb/noun Invoke-SpfDkimDmarc.
 
 ### Fixed
 - Not working if/elseif statement in SPF.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 [2.1] - 28-1-2026
 
+### Added
 - Added `-SkipUpdateCheck` on calling the module, to skip the update check against the PowerShellgallery
 - Added `Get-BIMIRecord` check, this function resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.
 

--- a/DomainHealthChecker.psd1
+++ b/DomainHealthChecker.psd1
@@ -70,7 +70,7 @@ PowerShellVersion = '5.1'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Invoke-SpfDkimDmarc', 'Get-SPFRecord', 'Get-DKIMRecord', 
-               'Get-DMARCRecord', 'Get-DNSSEC', 'Invoke-MtaSts', 'Get-BimiRecord'
+               'Get-DMARCRecord', 'Get-DNSSEC', 'Invoke-MtaSts', 'Get-BimiRecord', 'Update-ModuleDomainHealthChecker'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = '*'
@@ -79,7 +79,7 @@ CmdletsToExport = '*'
 VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'Show-SpfDkimDmarc', 'isdd', 'gspf', 'gdkim', 'gdmarc', 'gdnssec', 'gmts','gbimi'
+AliasesToExport = 'isdd', 'isdd', 'gspf', 'gdkim', 'gdmarc', 'gdnssec', 'gmts', 'gbimi'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()
@@ -103,13 +103,13 @@ PrivateData = @{
         LicenseUri = 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/LICENSE'
 
         # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/T13nn3s/Show-SpfDkimDmarc/'
+        ProjectUri = 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/'
 
         # A URL to an icon representing this module.
-        IconUri = 'https://raw.githubusercontent.com/T13nn3s/Show-SpfDkimDmarc/main/logo/Show-SpfDkimDmarc.png'
+        IconUri = 'https://raw.githubusercontent.com/T13nn3s/Invoke-SpfDkimDmarc/main/logo/Invoke-SpfDkimDmarc.png'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/CHANGELOG'
+        ReleaseNotes = 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/CHANGELOG'
 
         # Prerelease string of this module
         # Prerelease = ''
@@ -125,7 +125,7 @@ PrivateData = @{
  } # End of PrivateData hashtable
 
 # HelpInfo URI of this module
-HelpInfoURI = 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-SpfDkimDmarc.md'
+HelpInfoURI = 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-SpfDkimDmarc.md'
 
 # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
 # DefaultCommandPrefix = ''

--- a/DomainHealthChecker.psd1
+++ b/DomainHealthChecker.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DomainHealthChecker.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0'
+ModuleVersion = '2.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop','Core', 'Windows', 'Linux', 'macOS')
@@ -70,7 +70,7 @@ PowerShellVersion = '5.1'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Invoke-SpfDkimDmarc', 'Get-SPFRecord', 'Get-DKIMRecord', 
-               'Get-DMARCRecord', 'Get-DNSSEC', 'Invoke-MtaSts'
+               'Get-DMARCRecord', 'Get-DNSSEC', 'Invoke-MtaSts', 'Get-BimiRecord'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = '*'
@@ -79,7 +79,7 @@ CmdletsToExport = '*'
 VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'Show-SpfDkimDmarc', 'isdd', 'gspf', 'gdkim', 'gdmarc', 'gdnssec', 'gmts'
+AliasesToExport = 'Show-SpfDkimDmarc', 'isdd', 'gspf', 'gdkim', 'gdmarc', 'gdnssec', 'gmts','gbimi'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()
@@ -97,7 +97,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'Email','Emailsecurity','Security','SPF','DKIM','DMARC'
+        Tags = 'Email','Emailsecurity','Security','SPF','DKIM','DMARC','DNSSEC','MTA-STS','BIMI','DomainHealth','DomainHealthChecker'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/LICENSE'

--- a/DomainHealthChecker.psm1
+++ b/DomainHealthChecker.psm1
@@ -1,5 +1,5 @@
 <#>
-HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-SpfDkimDmarc.md'
+HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-SpfDkimDmarc.md'
 #>
 
 # Load public functions
@@ -42,18 +42,25 @@ function Invoke-SpfDkimDmarc {
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.",
             Position = 4)]
-        [string]$Server
+        [string]$Server,
+
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Skip the update check on module.",
+            Position = 5)]
+        [switch]$SkipUpdateCheck
     )
 
     begin {
 
         # Check if there is an update available
+        if (!$SkipUpdateCheck) {
         try {
-            Update-ModuleVersion -Verbose:$False
+            Update-ModuleDomainHealthChecker -Verbose:$False
         }
         catch {
             Write-Verbose "No update check could be performed: $_"
         }
+    }
 
         Write-Verbose "Starting $($MyInvocation.MyCommand)"
         $PSBoundParameters | Out-String | Write-Verbose

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 # Invoke-SpfDkimDmarc
-Invoke-SpfDkimDmarc is a function within the PowerShell module DomainHealthChecker that checks SPF, DKIM, and DMARC records for one or more domains. After installing the module, you can use Invoke-SpfDkimDmarc to check all three records at once. You can also check the records individually by using the cmdlets `Get-SPFRecord`, `Get-DKIMRecord`, `Get-DNSSec`, or `Get-DMARCRecord` to retrieve the record for a single domain.
+Invoke-SpfDkimDmarc is a function within the PowerShell module DomainHealthChecker that checks SPF, DKIM, BIMI, and DMARC records for one or more domains. After installing the module, you can use Invoke-SpfDkimDmarc to check all three records at once. You can also check the records individually by using the cmdlets `Get-SPFRecord`, `Get-DKIMRecord`, `Get-DNSSec`, `Get-BIMIrecord` or `Get-DMARCRecord` to retrieve the record for a single domain.
 
-![Invoke-SpfDkimDmarc](https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/logo/Show-SpfDkimDmarc.png)
+![Invoke-SpfDkimDmarc](https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/logo/Invoke-SpfDkimDmarc.png)
 
 ## System Requirements
 This module requires PowerShell version 5.1 or later on Windows, and PowerShell Core on Linux and macOS.
@@ -48,7 +48,7 @@ After installing this module, you have the following cmdlets at your disposal.
 - `Get-DMARCRecord` to check the DMARC record for a single domain. This cmdlet has also an alias `gdmarc` for quick checks.
 - `Get-DNSSec` to check whether the domain is protected with DNSSEC. This cmdlet has also an alias `gdnssec` for quick checks.
 - `Invoke-MtaSts` to check for the existence of the record and also checks for a valid MTA-STS Policy.
-- `Get-BimiRecord` to check for the existance of the record and also checks if the DMARC policy is configured properly according the needs of BIMI.
+- `Get-BIMIRecord` to check for the existance of the record and also checks if the DMARC policy is configured properly according the needs of BIMI.
 
 ## Split DNS environment
 If you are using a split DNS environment, you can use the `-Server` parameter to specify an alternative DNS server.
@@ -64,125 +64,126 @@ SpfRecord               : v=spf1 -all
 SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
 SPFRecordLength         : 11
 SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac
-                          3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers
-                           and spammers.
+DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
 DkimRecord              :
-DkimSelector            : zendesk2
+DkimSelector            : yandex
 DkimAdvisory            : We couldn't find a DKIM record associated with your domain.
-MtaRecord               :
+MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+DnsSec                  : Domain is DNSSEC signed.
+DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 ```
 
 Checks the SPF, DMARC, DKIM and Mta configuration for the domain binsec.nl.
 
 ### Example 2
 ```powershell
-PS C:\> Invoke-spfDkimDmarc binsec.nl, microsoft.nl -IncludeDNSSEC
+PS C:\> Invoke-spfDkimDmarc binsec.nl, microsoft.nl
 
 Name                    : binsec.nl
 SpfRecord               : v=spf1 -all
 SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
 SPFRecordLength         : 11
 SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac
-                          3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers
-                           and spammers.
+DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
 DkimRecord              :
-DkimSelector            : zendesk2
+DkimSelector            : yandex
 DkimAdvisory            : We couldn't find a DKIM record associated with your domain.
-MtaRecord               :
+MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
 DnsSec                  : Domain is DNSSEC signed.
 DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 
 Name                    : microsoft.nl
 SpfRecord               : v=spf1 mx -all v=spf1 +a +mx include:sendgrid.net -all
-SpfAdvisory             : Domain has more than one SPF record. Only one SPF record per domain is allowed. This is expli
-                          citly defined in RFC4408.
+SpfAdvisory             : Domain has more than one SPF record. Only one SPF record per domain is allowed. This is explicitly defined in RFC4408.
 SPFRecordLength         : 53
 SPFRecordDnsLookupCount : 3/10 (OK)
 DmarcRecord             :
-DmarcAdvisory           : Does not have a DMARC record. This domain is at risk to being abused by phishers and spammers
-                          .
+DmarcAdvisory           : Does not have a DMARC record. This domain is at risk to being abused by phishers and spammers.
 DkimRecord              :
-DkimSelector            : zendesk2
+DkimSelector            : yandex
 DkimAdvisory            : We couldn't find a DKIM record associated with your domain.
-MtaRecord               :
+MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : No BIMI record found for domain.BIMI record found. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
 DnsSec                  : No DNSKEY records found.
 DnsSecAdvisory          : Enable DNSSEC on your domain. DNSSEC decreases the vulnerability to DNS attacks.
 ```
 
-Checks the SPF, DMARC, DKIM, Mta and DNSSEC configuration for the domains binsec.nl and microsoft.com.
+Checks the SPF, DMARC, DKIM, Mta and DNSSEC configuration for the domains binsec.nl and microsoft.nl.
 
 ### Example 3
 ```powershell
-PS C:\> Invoke-spfDkimDmarc binsec.nl, ing.nl -dkimselector selector1 -IncludeDNSSEC -server 1.1.1.1
+PS C:\> Invoke-spfDkimDmarc binsec.nl, ing.nl -dkimselector selector1 -server 1.1.1.1
 
 Name                    : binsec.nl
 SpfRecord               : v=spf1 -all
 SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
 SPFRecordLength         : 11
 SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac
-                          3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers
-                           and spammers.
+DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
 DkimRecord              :
 DkimSelector            : selector1
 DkimAdvisory            : No DKIM-record found for selector selector1._domainkey.binsec.nl
 MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
 DnsSec                  : Domain is DNSSEC signed.
 DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 
 Name                    : ing.nl
-SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.
-                          86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9 ip4:91.220.136.168 ip4:46
-                          .31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.1
-                          12.237.21 ip4:62.112.237.23 ip6:2a00:1558:2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.
-                          ing.net include:_spf.ing.nl -all
-SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicit
-                          ly defined in RFC4408. An SPF-record is configured and the policy is sufficiently strict.
+SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9
+                           ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112.237.21 ip4:62.112.237.23 ip6:2a00:1558
+                          :2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.ing.net include:_spf.ing.nl -all
+SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configured and the policy i
+                          s sufficiently strict.
 SPFRecordLength         : 404
 SPFRecordDnsLookupCount : 4/10 (OK)
-DmarcRecord             : v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mai
-                          lto:dmarc.feedback@ing.nl
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers
-                           and spammers.
-DkimRecord              : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx
-                          1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCpdtMaXjmYVG9zvSx74HUBb223TqMve8K1qBU/sW2I3ZijuP
-                          /37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;
+DmarcRecord             : v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mailto:dmarc.feedback@ing.nl
+DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord              : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCpdtMaXjmYVG9zvSx74HUB
+                          b223TqMve8K1qBU/sW2I3ZijuP/37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;
 DkimSelector            : selector1
 DkimAdvisory            : DKIM-record found.
 MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : v=spf1 -all
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
 DnsSec                  : Domain is DNSSEC signed.
 DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 ```
 
-Checks the SPF, DMARC, DKIM for dkimselector selector2, Mta and DNSSEC configuration for the domains binsec.nl and microsoft.com using 1.1.1.1 as the DNS Server for the lookup.
+Checks the SPF, DMARC, DKIM for dkimselector selector2, Mta and DNSSEC configuration for the domains binsec.nl and ing.nl using 1.1.1.1 as the DNS Server for the lookup.
 
 ### Example 3
 ```powershell
-Invoke-SpfDkimDmarc -File $env:USERPROFILE\Desktop\domains.txt
+Invoke-SpfDkimDmarc -File $env:USERPROFILE\Desktop\domains.txt -Server 1.1.1.1
 
 Name                    : binsec.nl
 SpfRecord               : v=spf1 -all
 SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
 SPFRecordLength         : 11
 SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac
-                          3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers
-                           and spammers.
+DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
 DkimRecord              :
 DkimSelector            : yandex
 MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+DnsSec                  : Domain is DNSSEC signed.
+DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 
 Name                    : itsecuritymatters.nl
 SpfRecord               : v=spf1 include:_spf.protonmail.ch ~all
@@ -191,24 +192,44 @@ SPFRecordLength         : 38
 SPFRecordDnsLookupCount : 1/10 (OK)
 DmarcRecord             : v=DMARC1; p=reject; pct=100;
 DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              : v=DKIM1;k=rsa;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9MKqr+i7WAJnICEl4XNrMd0yThw0vszkgJRim0i5U8+KnDW9GvhVZ4qXDTAcKRQFqGBTgoOk4QJpAnUCQEOVVkpMrhDl24isMnShqfCVdTvVZv/a627KD6gKMU8+8tNH3TpBWSJaa7C96mxSj5eNuEg3gdCSq6wXOypnwtW2GMr+UgRsonsDYDGpUENxl0MYib/ yy5Pz6qm31foiKeQLV8gLk7MAhoXek085EVT8CGFnDY/j3ODAEyLXfs8lUaqIZCgCaTrCABbB5aX4fiWr8blahEbvNNC8RL
-                          01ne4dAhaotEonVYgHrVAOA3+u1d/m+nG9q9vQ5kD411S4s/Wv8wIDAQAB;
+DkimRecord              : v=DKIM1;k=rsa;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9MKqr+i7WAJnICEl4XNrMd0yThw0vszkgJRim0i5U8+KnDW9GvhVZ4qXDTAcKRQFqGBTgoOk4QJpAnUCQEOVVkpMrhDl24isMnSh
+                          qfCVdTvVZv/a627KD6gKMU8+8tNH3TpBWSJaa7C96mxSj5eNuEg3gdCSq6wXOypnwtW2GMr+UgRsonsDYDGpUENxl0MYib/ yy5Pz6qm31foiKeQLV8gLk7MAhoXek085EVT8CGFnDY/j3ODAEyLXfs8lUaqIZCg
+                          CaTrCABbB5aX4fiWr8blahEbvNNC8RL01ne4dAhaotEonVYgHrVAOA3+u1d/m+nG9q9vQ5kD411S4s/Wv8wIDAQAB;
 DkimSelector            : protonmail
 MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+DnsSec                  : No DNSKEY records found.
+DnsSecAdvisory          : Enable DNSSEC on your domain. DNSSEC decreases the vulnerability to DNS attacks.
 
 Name                    : ing.nl
-SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9 ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112.237.21 ip4:62.112.237.23 ip6:2a00:1558:2801:4::2:1 ip6:2a00:1558:2801
-                          :4::3:1 include:_spf.ing.net include:_spf.ing.nl -all
-SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configured and the policy is sufficiently strict.
+SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9
+                           ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112.237.21 ip4:62.112.237.23 ip6:2a00:1558
+                          :2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.ing.net include:_spf.ing.nl -all
+SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configured and the policy i
+                          s sufficiently strict.
 SPFRecordLength         : 404
 SPFRecordDnsLookupCount : 4/10 (OK)
 DmarcRecord             : v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mailto:dmarc.feedback@ing.nl
 DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCpdtMaXjmYVG9zvSx74HUBb223TqMve8K1qBU/sW2I3ZijuP/37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;
+DkimRecord              : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCpdtMaXjmYVG9zvSx74HUB
+                          b223TqMve8K1qBU/sW2I3ZijuP/37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;
 DkimSelector            : selector1
 MtaRecord               : No MTA-STS DNS record found.
 MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+BimiRecord              : v=spf1 -all
+BimiAdvisory            : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+DnsSec                  : Domain is DNSSEC signed.
+DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
 ```
 
-Checks the SPF, DMARC, DKIM for dkimselector zendesk1, Mta and DNSSEC configuration for the domains binsec.nl, itsecuritymatters.nl, microsoft.com using `1.1.1.1` as the DNS Server for the lookup. The domains are listed in the file `domains.txt`.
+Get's the contents of the file `domains.txt`, and itterates through the domains to perform all the checks against the domains by using the `1.1.1.1` as the DNS Server for the lookup. The domains are listed in the file `domains.txt`.
+
+Contents of the file `domains.txt`:
+
+```
+binsec.nl
+itsecuritymatters.nl
+ing.nl
+```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ After installing this module, you have the following cmdlets at your disposal.
 - `Get-DMARCRecord` to check the DMARC record for a single domain. This cmdlet has also an alias `gdmarc` for quick checks.
 - `Get-DNSSec` to check whether the domain is protected with DNSSEC. This cmdlet has also an alias `gdnssec` for quick checks.
 - `Invoke-MtaSts` to check for the existence of the record and also checks for a valid MTA-STS Policy.
+- `Get-BimiRecord` to check for the existance of the record and also checks if the DMARC policy is configured properly according the needs of BIMI.
 
 ## Split DNS environment
 If you are using a split DNS environment, you can use the `-Server` parameter to specify an alternative DNS server.

--- a/en-US/DomainHealthChecker-help.xml
+++ b/en-US/DomainHealthChecker-help.xml
@@ -2,15 +2,206 @@
 <helpItems schema="maml" xmlns="http://msh">
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-BimiRecord</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>BimiRecord</command:noun>
+      <maml:description>
+        <maml:para>Resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Get-BIMIRecord queries a domain's BIMI TXT record (optionally using a specified selector), evaluates the record contents, verifies the domain's DMARC policy for BIMI compatibility (requires p=quarantine or p=reject and pct=100), and inspects any referenced VMC certificate (from the a= tag) for a valid HTTPS URL and expiration. Returns a PSCustomObject per domain with properties: Name, BimiRecord, and BimiAdvisory. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS (dnsutils required). Accepts an optional DNS server parameter for resolution.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-BimiRecord</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the domain for resolving the BIMI-record.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>Selector</maml:name>
+          <maml:description>
+            <maml:para>Specify BIMI selector to query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>DNS Server to use.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Specifies the domain for resolving the BIMI-record.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>Selector</maml:name>
+        <maml:description>
+          <maml:para>Specify BIMI selector to query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>DNS Server to use.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-BIMIrecord binsec.nl | fl *
+
+Name         : binsec.nl
+BimiRecord   : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.</dev:code>
+        <dev:remarks>
+          <maml:para>Queries the BIMI record for the domain binsec.nl</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-BIMIRecord binsec.nl, dmarcadvisor.com
+
+Name             BimiRecord                                                                                                                                BimiAdvisory
+----             ----------                                                                                                                                ------------
+binsec.nl        We couldn't find a BIMI record associated with your domain.                                                                               DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+dmarcadvisor.com v=BIMI1; l=https://bimi.eu.dmarcmanager.app/eu-2o4fmqie/default/logo.svg; a=https://bimi.eu.dmarcmanager.app/eu-2o4fmqie/default/cert.pem DMARC policy is set to p=reject, which is the best policy for BIMI to function. 'a=' (VMC) tag contains a valid HTTPS URL.</dev:code>
+        <dev:remarks>
+          <maml:para>Queries the BIMI record for the domains binsec.nl and dmarcadvisor.com</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-BIMIRecord bimigroup.org -server 1.1.1.1
+
+Name          BimiRecord                                       BimiAdvisory
+----          ----------                                       ------------
+bimigroup.org v=BIMI1; l=https://bimigroup.org/bimi-sq.svg; a= DMARC policy is set to p=reject, which is the best policy for BIMI to function. 'a=' (VMC) tag does not contain a valid HTTPS URL, it should start with 'https://'. It's recommended to use a valid HTTPS URL for VMC to prevent that scammers misuse your logo.</dev:code>
+        <dev:remarks>
+          <maml:para>Queries the BIMI record for the domain bimigroup.org using an alternative DNS server.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-BIMIecord.md</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Get-BIMIRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
+        <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-DKIMRecord</command:name>
       <command:verb>Get</command:verb>
       <command:noun>DKIMRecord</command:noun>
       <maml:description>
-        <maml:para>Function to resolve a DKIM record of a domain.</maml:para>
+        <maml:para>Retrieves and validates DKIM records for one or more domains.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>It is important to configure DKIM on an emaildomain and sending emailserver. DKIM stands for DomainKeys Identified Mail, and it's an verification protocol for verifying the legitimacy of the sender, to prevent email spoofing. This PowerShell function can resolve an DKIM record of an emaildomain and give an advisory regarding the current configuration. It's possible use a custom DKIM-selector.</maml:para>
+      <maml:para>Get-DKIMRecord queries DKIM records using a provided selector or a list of common selectors, follows CNAME chains to locate records, and reports findings and advisories per domain. It supports Windows (Resolve-DnsName) and Linux/macOS (dig), accepts an optional DNS server, and returns objects with Name, DkimRecord, DkimSelector, and DKIMAdvisory properties.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -51,6 +242,18 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -86,6 +289,18 @@
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -147,11 +362,15 @@ DKIMAdvisory : DKIM-record found.</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>Get-DKIMRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery</maml:linkText>
+        <maml:linkText>Get-DKIMRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
         <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -161,11 +380,11 @@ DKIMAdvisory : DKIM-record found.</dev:code>
       <command:verb>Get</command:verb>
       <command:noun>DMARCRecord</command:noun>
       <maml:description>
-        <maml:para>Function to resolve a DMARC record of a domain.</maml:para>
+        <maml:para>Retrieves and assesses a domain's DMARC record.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>It is important to configure DMARC on your emaildomain. DMARC stands for Domain-based Message Authentication, Reporting and Conformance. It is a policy-based protocol for enforcing a specific policy to email traffic sent on behalf of an email domain. DMARC works closely with the SPF and DKIM records, to prevent email spoofing. This PowerShell function can resolve an DMARC record of a domain and give an advisory regarding the current configuration.</maml:para>
+      <maml:para>Get-DMARCRecord queries the _dmarc TXT record for one or more domains, evaluates the DMARC policy and subdomain policy (p= and sp=), and returns a PSCustomObject per domain with properties: Name, DmarcRecord, and DmarcAdvisory. Supports Windows (Resolve-DnsName) and Linux/macOS (dig) and accepts an optional DNS server parameter for resolution.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -274,11 +493,15 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>Get-DMARCRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery</maml:linkText>
+        <maml:linkText>Get-DMARCRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
         <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -288,11 +511,11 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
       <command:verb>Get</command:verb>
       <command:noun>DNSSec</command:noun>
       <maml:description>
-        <maml:para>Function that checks whether DNSSEC is configured</maml:para>
+        <maml:para>Determines whether one or more domains are DNSSEC-signed.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>DNSSEC creates a secure domain name system by adding cryptographic signatures to existing DNS records. These digital signatures are stored in DNS name servers alongside common record types like A, AAAA, MX, CNAME, etc. By checking its associated signature, you can verify that a requested DNS record comes from its authoritative name server and wasn't altered en-route, opposed to a fake record injected in a man-in-the-middle attack.</maml:para>
+      <maml:para>Get-DNSSec queries DNSKEY records for the specified domain(s) and evaluates DNSSEC configuration (flags and protocol) per RFC4034. On Windows it uses Resolve-DnsName; on Linux/macOS it uses dig (dnsutils required). Returns PSCustomObject(s) with properties: Name, DNSSEC, and DnsSecAdvisory. Supports an optional -Server parameter to query a specific DNS server.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -317,6 +540,18 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -348,11 +583,23 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes>
       <command:inputType>
         <dev:type>
-          <maml:name>System.String</maml:name>
+          <maml:name>System.String[]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -377,7 +624,7 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt;  Get-DNSSec -Name binsec.nl</dev:code>
+        <dev:code>PS C:\&gt; Get-DNSSec -Name binsec.nl</dev:code>
         <dev:remarks>
           <maml:para>This example resolved the DNSSEC records for the specified domain.</maml:para>
         </dev:remarks>
@@ -386,15 +633,19 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DNSSec.md</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>A Gentle Introduction to DNSSEC</maml:linkText>
         <maml:uri>https://www.cloudflare.com/dns/dnssec/how-dnssec-works/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>Get-SPFRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery</maml:linkText>
+        <maml:linkText>Get-DNSSec is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
         <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -404,11 +655,11 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
       <command:verb>Get</command:verb>
       <command:noun>SPFRecord</command:noun>
       <maml:description>
-        <maml:para>Function to resolve the SPF-record of a domain.</maml:para>
+        <maml:para>Retrieves and evaluates SPF (Sender Policy Framework) records for one or more domains.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>It is important to configure an SPF record on your emaildomain. SPF stands for Sender Policy Framework, and it's an authentication protocol to prevent email spoofing. This PowerShell function can resolve an SPF record of a emaildomain and give an advisory regarding the current configuration.</maml:para>
+      <maml:para>Get-SPFRecord locates a domain's SPF TXT record (v=spf1), follows SPF redirects, counts nested DNS lookups (enforcing the RFC7208 limit), checks record and token lengths, and evaluates the SPF qualifier to produce actionable advisories. The cmdlet returns PSCustomObject(s) with properties: Name, SPFRecord, SPFRecordLength, SPFRecordDnsLookupCount, and SPFAdvisory. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS; accepts an optional -Server parameter for custom DNS resolution.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -433,6 +684,18 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -464,11 +727,23 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes>
       <command:inputType>
         <dev:type>
-          <maml:name>System.String</maml:name>
+          <maml:name>System.String[]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -493,11 +768,13 @@ binsec.nl v=DMARC1; p=none; pct=100   Domain has a valid DMARC record but the DM
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; Get-SPFRecord -Name binsec.nl
+        <dev:code>PS C:\&gt; get-spfrecord binsec.nl
 
-Name      SPFRecord                              SPFAdvisory
-----      ---------                              -----------
-binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and the policy is sufficiently strict.</dev:code>
+Name                    : binsec.nl
+SPFRecord               : v=spf1 -all
+SPFRecordLength         : 11
+SPFRecordDnsLookupCount : 0/10 (OK)
+SPFAdvisory             : An SPF-record is configured and the policy is sufficiently strict.</dev:code>
         <dev:remarks>
           <maml:para>This example resolves the SPF record for the domain binsec.nl.</maml:para>
         </dev:remarks>
@@ -506,9 +783,11 @@ binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and
         <maml:title>-------------------------- Example 2 --------------------------</maml:title>
         <dev:code>PS C:\&gt; Get-SPFRecord -Name binsec.nl -Server 10.0.0.1
 
-Name      SPFRecord                              SPFAdvisory
-----      ---------                              -----------
-binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and the policy is sufficiently strict.</dev:code>
+Name                    : binsec.nl
+SPFRecord               : v=spf1 -all
+SPFRecordLength         : 11
+SPFRecordDnsLookupCount : 0/10 (OK)
+SPFAdvisory             : An SPF-record is configured and the policy is sufficiently strict.</dev:code>
         <dev:remarks>
           <maml:para>This example resolves the SPF-record for the domain binsec.nl against the DNS server at 10.0.0.1.</maml:para>
         </dev:remarks>
@@ -517,11 +796,15 @@ binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>Get-SPFRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery</maml:linkText>
+        <maml:linkText>Get-SPFRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
         <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -531,11 +814,11 @@ binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and
       <command:verb>Invoke</command:verb>
       <command:noun>MtaSts</command:noun>
       <maml:description>
-        <maml:para>Function to check for MTA-STS DNS TXT Record and Valid MTA-STS Policy</maml:para>
+        <maml:para>Validates a domain's MTA-STS DNS record and policy file and reports MX TLS support.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>MTA-STS (Mail Transfer Agent Strict Transport Security) is a security mechanism designed to enforce the use of encrypted (TLS) connections for email in transit, helping to prevent man-in-the-middle attacks on email communication. It enables domain owners to specify that emails sent to their domain should only be accepted over secure TLS connections and to define a policy for handling messages if secure transmission fails.</maml:para>
+      <maml:para>Invoke-MtaSts checks the _mta-sts TXT DNS record and downloads the MTA-STS policy file from https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt. It validates record format (version and id), evaluates the policy file (version, mode, max_age, and listed mx entries), compares policy MX entries to actual MX DNS records, and tests whether MX hosts support STARTTLS. Returns PSCustomObject(s) with Name, mtaRecord, and mtaAdvisory properties. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS; accepts an optional -Server parameter for custom DNS resolution.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -564,6 +847,18 @@ binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -587,6 +882,18 @@ binsec.nl v=spf1 include:_spf.transip.email -all An SPF-record is configured and
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -656,7 +963,15 @@ microsoft.com v=STSv1; id=20190225000000Z; The domain has the MTA-STS DNS record
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Get-MtaSts is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
+        <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -711,16 +1026,17 @@ microsoft.com v=STSv1; id=20190225000000Z; The domain has the MTA-STS DNS record
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
-          <maml:name>IncludeDNSSEC</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
           <maml:description>
-            <maml:para>Include this switch to check for DNSSEC existance</maml:para>
+            <maml:para></maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
           <dev:type>
-            <maml:name>SwitchParameter</maml:name>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -761,16 +1077,17 @@ microsoft.com v=STSv1; id=20190225000000Z; The domain has the MTA-STS DNS record
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
-          <maml:name>IncludeDNSSEC</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
           <maml:description>
-            <maml:para>Include this switch to check for DNSSEC existance</maml:para>
+            <maml:para></maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
           <dev:type>
-            <maml:name>SwitchParameter</maml:name>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -799,18 +1116,6 @@ microsoft.com v=STSv1; id=20190225000000Z; The domain has the MTA-STS DNS record
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
-        <maml:name>IncludeDNSSEC</maml:name>
-        <maml:description>
-          <maml:para>Include this switch to check for DNSSEC existance</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
         <maml:name>Name</maml:name>
         <maml:description>
@@ -831,6 +1136,18 @@ microsoft.com v=STSv1; id=20190225000000Z; The domain has the MTA-STS DNS record
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1008,7 +1325,15 @@ MtaAdvisory     : The domain has the MTA-STS DNS record and file configured and 
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md</maml:uri>
+        <maml:uri>https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Invoke-SpfDkimDmarc is part of the 'DomainHealthChecker' module, available on the PowerShellGallery</maml:linkText>
+        <maml:uri>https://www.powershellgallery.com/packages/DomainHealthChecker/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project site on Github</maml:linkText>
+        <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/private/Update-ModuleDomainHealthChecker.ps1
+++ b/private/Update-ModuleDomainHealthChecker.ps1
@@ -5,10 +5,10 @@ Checks the installed DomainHealthChecker module version and updates it if a newe
 .DESCRIPTION
 This function checks if there is a newer version of the DomainHealthChecker module available on the PowerShell Gallery.
 .EXAMPLE
-Update-ModuleVersion
+Update-ModuleDomainHealthChecker
 #>
 
-function Update-ModuleVersion {
+function Update-ModuleDomainHealthChecker {
     [CmdletBinding()]
     param()
 
@@ -44,13 +44,17 @@ function Update-ModuleVersion {
                         Write-Host "[+] Module updated successfully to version $CurrentVersionOnPowerShellGallery." -ForegroundColor Green
                     }
                     catch {
+                        Write-Verbose "Error occurred during module update: $_. Trying alternative update method."
+                        Install-Module -Name DomainHealthChecker -Force -AllowClobber -ErrorAction Stop
+                        
+                    } finally {
                         Write-Verbose "Error occurred while updating module: $_"
                         Write-Error "[-] Failed to update the DomainHealthChecker module. Please try updating it manually."
                     }
                 }
                 { $_.ToLower() -eq 'n' } {
                     Write-Verbose "User chose not to update 'DomainHealthChecker'."
-                    Write-Host "[*] Module update skipped. You can update the module later by running Update-ModuleVersion." -ForegroundColor Yellow
+                    Write-Host "[*] Module update skipped. You can update the module later by running Update-ModuleDomainHealthChecker." -ForegroundColor Yellow
                 }
                 Default {
                     Write-Verbose "User input not recognized, assuming 'No'."

--- a/public/CmdletHelp/Get-BIMIRecord.md
+++ b/public/CmdletHelp/Get-BIMIRecord.md
@@ -1,0 +1,136 @@
+---
+external help file: DomainHealthChecker-help.xml
+Module Name: DomainHealthChecker
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-BIMIecord.md
+schema: 2.0.0
+---
+
+# Get-BimiRecord
+
+## SYNOPSIS
+Resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.
+
+## SYNTAX
+
+```
+Get-BimiRecord [-Name] <String[]> [[-Selector] <String>] [[-Server] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Get-BIMIRecord queries a domain's BIMI TXT record (optionally using a specified selector), evaluates the record contents, verifies the domain's DMARC policy for BIMI compatibility (requires p=quarantine or p=reject and pct=100), and inspects any referenced VMC certificate (from the a= tag) for a valid HTTPS URL and expiration. Returns a PSCustomObject per domain with properties: Name, BimiRecord, and BimiAdvisory. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS (dnsutils required). Accepts an optional DNS server parameter for resolution.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-BIMIrecord binsec.nl | fl *
+
+Name         : binsec.nl
+BimiRecord   : We couldn't find a BIMI record associated with your domain.
+BimiAdvisory : DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+```
+
+Queries the BIMI record for the domain binsec.nl
+
+### Example 2
+```powershell
+PS C:\> Get-BIMIRecord binsec.nl, dmarcadvisor.com
+
+Name             BimiRecord                                                                                                                                BimiAdvisory
+----             ----------                                                                                                                                ------------
+binsec.nl        We couldn't find a BIMI record associated with your domain.                                                                               DMARC policy is set to p=reject, which is the best policy for BIMI to function. No 'a=' (VMC) tag found, it's recommended to include a VMC certificate.
+dmarcadvisor.com v=BIMI1; l=https://bimi.eu.dmarcmanager.app/eu-2o4fmqie/default/logo.svg; a=https://bimi.eu.dmarcmanager.app/eu-2o4fmqie/default/cert.pem DMARC policy is set to p=reject, which is the best policy for BIMI to function. 'a=' (VMC) tag contains a valid HTTPS URL.
+```
+
+Queries the BIMI record for the domains binsec.nl and dmarcadvisor.com
+
+### Example 3
+```powershell
+PS C:\> Get-BIMIRecord bimigroup.org -server 1.1.1.1
+
+Name          BimiRecord                                       BimiAdvisory
+----          ----------                                       ------------
+bimigroup.org v=BIMI1; l=https://bimigroup.org/bimi-sq.svg; a= DMARC policy is set to p=reject, which is the best policy for BIMI to function. 'a=' (VMC) tag does not contain a valid HTTPS URL, it should start with 'https://'. It's recommended to use a valid HTTPS URL for VMC to prevent that scammers misuse your logo.
+```
+
+Queries the BIMI record for the domain bimigroup.org using an alternative DNS server.
+
+## PARAMETERS
+
+### -Name
+Specifies the domain for resolving the BIMI-record.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Selector
+Specify BIMI selector to query.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+DNS Server to use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[Get-BIMIRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Get-DKIMRecord.md
+++ b/public/CmdletHelp/Get-DKIMRecord.md
@@ -1,14 +1,14 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md
 schema: 2.0.0
 ---
 
 # Get-DKIMRecord
 
 ## SYNOPSIS
-Function to resolve a DKIM record of a domain.
+Retrieves and validates DKIM records for one or more domains.
 
 ## SYNTAX
 
@@ -17,10 +17,7 @@ Get-DKIMRecord [-Name] <String[]> [[-DkimSelector] <String>] [[-Server] <String>
 ```
 
 ## DESCRIPTION
-It is important to configure DKIM on an emaildomain and sending emailserver.
-DKIM stands for DomainKeys Identified Mail, and it's an verification protocol for verifying the legitimacy of the sender, to prevent email spoofing.
-This PowerShell function can resolve an DKIM record of an emaildomain and give an advisory regarding the current configuration.
-It's possible use a custom DKIM-selector.
+Get-DKIMRecord queries DKIM records using a provided selector or a list of common selectors, follows CNAME chains to locate records, and reports findings and advisories per domain. It supports Windows (Resolve-DnsName) and Linux/macOS (dig), accepts an optional DNS server, and returns objects with Name, DkimRecord, DkimSelector, and DKIMAdvisory properties.
 
 ## EXAMPLES
 
@@ -98,6 +95,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -111,5 +122,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-DKIMRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+[Get-DKIMRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
 
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Get-DMARCRecord.md
+++ b/public/CmdletHelp/Get-DMARCRecord.md
@@ -1,14 +1,14 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md
 schema: 2.0.0
 ---
 
 # Get-DMARCRecord
 
 ## SYNOPSIS
-Function to resolve a DMARC record of a domain.
+Retrieves and assesses a domain's DMARC record.
 
 ## SYNTAX
 
@@ -18,11 +18,7 @@ Get-DMARCRecord [-Name] <String[]> [[-Server] <String>]
 ```
 
 ## DESCRIPTION
-It is important to configure DMARC on your emaildomain.
-DMARC stands for Domain-based Message Authentication, Reporting and Conformance.
-It is a policy-based protocol for enforcing a specific policy to email traffic sent on behalf of an email domain.
-DMARC works closely with the SPF and DKIM records, to prevent email spoofing.
-This PowerShell function can resolve an DMARC record of a domain and give an advisory regarding the current configuration.
+Get-DMARCRecord queries the _dmarc TXT record for one or more domains, evaluates the DMARC policy and subdomain policy (p= and sp=), and returns a PSCustomObject per domain with properties: Name, DmarcRecord, and DmarcAdvisory. Supports Windows (Resolve-DnsName) and Linux/macOS (dig) and accepts an optional DNS server parameter for resolution.
 
 ## EXAMPLES
 
@@ -93,5 +89,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-DMARCRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+[Get-DMARCRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
 
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Get-DNSSec.md
+++ b/public/CmdletHelp/Get-DNSSec.md
@@ -1,14 +1,14 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DNSSec.md
 schema: 2.0.0
 ---
 
 # Get-DNSSec
 
 ## SYNOPSIS
-Function that checks whether DNSSEC is configured
+Determines whether one or more domains are DNSSEC-signed.
 
 ## SYNTAX
 
@@ -17,7 +17,7 @@ Get-DNSSec [-Name] <String[]> [[-Server] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-DNSSEC creates a secure domain name system by adding cryptographic signatures to existing DNS records. These digital signatures are stored in DNS name servers alongside common record types like A, AAAA, MX, CNAME, etc. By checking its associated signature, you can verify that a requested DNS record comes from its authoritative name server and wasn't altered en-route, opposed to a fake record injected in a man-in-the-middle attack.
+Get-DNSSec queries DNSKEY records for the specified domain(s) and evaluates DNSSEC configuration (flags and protocol) per RFC4034. On Windows it uses Resolve-DnsName; on Linux/macOS it uses dig (dnsutils required). Returns PSCustomObject(s) with properties: Name, DNSSEC, and DnsSecAdvisory. Supports an optional -Server parameter to query a specific DNS server.
 
 ## EXAMPLES
 
@@ -60,12 +60,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.String
+### System.String[]
 
 ## OUTPUTS
 
@@ -75,4 +89,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [A Gentle Introduction to DNSSEC](https://www.cloudflare.com/dns/dnssec/how-dnssec-works/)
-[Get-SPFRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+
+[Get-DNSSec is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Get-SPFRecord.md
+++ b/public/CmdletHelp/Get-SPFRecord.md
@@ -1,14 +1,14 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md
 schema: 2.0.0
 ---
 
 # Get-SPFRecord
 
 ## SYNOPSIS
-Function to resolve the SPF-record of a domain.
+Retrieves and evaluates SPF (Sender Policy Framework) records for one or more domains.
 
 ## SYNTAX
 
@@ -17,9 +17,7 @@ Get-SPFRecord [-Name] <String[]> [[-Server] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-It is important to configure an SPF record on your emaildomain.
-SPF stands for Sender Policy Framework, and it's an authentication protocol to prevent email spoofing.
-This PowerShell function can resolve an SPF record of a emaildomain and give an advisory regarding the current configuration.
+Get-SPFRecord locates a domain's SPF TXT record (v=spf1), follows SPF redirects, counts nested DNS lookups (enforcing the RFC7208 limit), checks record and token lengths, and evaluates the SPF qualifier to produce actionable advisories. The cmdlet returns PSCustomObject(s) with properties: Name, SPFRecord, SPFRecordLength, SPFRecordDnsLookupCount, and SPFAdvisory. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS; accepts an optional -Server parameter for custom DNS resolution.
 
 ## EXAMPLES
 
@@ -81,12 +79,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.String
+### System.String[]
+
 ## OUTPUTS
 
 ### System.Object
@@ -94,5 +107,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-SPFRecord is part of the 'DomainHealthChecker' module on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+[Get-SPFRecord is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
 
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Invoke-MtaSts.md
+++ b/public/CmdletHelp/Invoke-MtaSts.md
@@ -1,14 +1,14 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md
 schema: 2.0.0
 ---
 
 # Invoke-MtaSts
 
 ## SYNOPSIS
-Function to check for MTA-STS DNS TXT Record and Valid MTA-STS Policy
+Validates a domain's MTA-STS DNS record and policy file and reports MX TLS support.
 
 ## SYNTAX
 
@@ -17,7 +17,7 @@ Invoke-MtaSts [-Name] <String[]> [[-Server] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-MTA-STS (Mail Transfer Agent Strict Transport Security) is a security mechanism designed to enforce the use of encrypted (TLS) connections for email in transit, helping to prevent man-in-the-middle attacks on email communication. It enables domain owners to specify that emails sent to their domain should only be accepted over secure TLS connections and to define a policy for handling messages if secure transmission fails.
+Invoke-MtaSts checks the _mta-sts TXT DNS record and downloads the MTA-STS policy file from https://mta-sts.<domain>/.well-known/mta-sts.txt. It validates record format (version and id), evaluates the policy file (version, mode, max_age, and listed mx entries), compares policy MX entries to actual MX DNS records, and tests whether MX hosts support STARTTLS. Returns PSCustomObject(s) with Name, mtaRecord, and mtaAdvisory properties. Cross-platform: uses Resolve-DnsName on Windows and dig on Linux/macOS; accepts an optional -Server parameter for custom DNS resolution.
 
 ## EXAMPLES
 
@@ -87,6 +87,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -100,3 +114,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-MtaSts is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Invoke-SpfDkimDmarc.md
+++ b/public/CmdletHelp/Invoke-SpfDkimDmarc.md
@@ -1,181 +1,171 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md
 schema: 2.0.0
 ---
 
 # Invoke-SpfDkimDmarc
 
 ## SYNOPSIS
-Module for checking SPF, DKIM, DMARC and MtaSts. This module also checks for the DNSSEC configuration.
+Module for checking SPF, DKIM, DMARC and MtaSts.
+This module also checks for the DNSSEC configuration.
 
 ## SYNTAX
 
 ### domain
 ```
-Invoke-SpfDkimDmarc [-Name] <String[]> [[-DkimSelector] <String>] [[-Server] <String>] [-IncludeDNSSEC] [<CommonParameters>]
+Invoke-SpfDkimDmarc [-Name] <String[]> [[-DkimSelector] <String>] [[-Server] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### file
 ```
-Invoke-SpfDkimDmarc [-File] <FileInfo> [[-DkimSelector] <String>] [[-Server] <String>] [-IncludeDNSSEC] [<CommonParameters>]
+Invoke-SpfDkimDmarc [-File] <FileInfo> [[-DkimSelector] <String>] [[-Server] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Invoke-SpfDkimDmarc is a module within the PowerShell module named DomainHealthChecker that can check the SPF, DKIM and DMARC record for one or multiple domains. On installing this module you can use Invoke-SpfDKimDmarc to check the records. You can also check the records individually by using the cmdlets Get-SPFrecord, Get-DKIMRecord or by running the Get-DMARCRecord to check the record of a single domain.
+Invoke-SpfDkimDmarc is a module within the PowerShell module named DomainHealthChecker that can check the SPF, DKIM and DMARC record for one or multiple domains.
+On installing this module you can use Invoke-SpfDKimDmarc to check the records.
+You can also check the records individually by using the cmdlets Get-SPFrecord, Get-DKIMRecord or by running the Get-DMARCRecord to check the record of a single domain.
 
 ## EXAMPLES
 
 ### Example 1
-```powershell
+```
 PS C:\> Invoke-spfDkimDmarc binsec.nl
 
-Name                    : binsec.nl
-SpfRecord               : v=spf1 -all
-SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
-SPFRecordLength         : 11
-SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : yandex
-DkimAdvisory            : We couldn't find a DKIM record associated with your domain.
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+Name            : binsec.nl
+SpfRecord       : v=spf1 -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 11
+DmarcRecord     : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : dkim
+DkimAdvisory    : We couldn't find a DKIM record associated with your domain.
+MtaRecord       :
+MtaAdvisory     : The MTA-STS DNS record doesn't exist.
 ```
 
 Checks the SPF, DMARC, DKIM and Mta configuration for the domain binsec.nl.
 
 ### Example 2
-```powershell
-PS C:\> Invoke-spfDkimDmarc binsec.nl, ing.nl -IncludeDNSSEC
+```
+PS C:\> Invoke-spfDkimDmarc binsec.nl, microsoft.com -IncludeDNSSEC
 
-Name                    : binsec.nl
-SpfRecord               : v=spf1 -all
-SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
-SPFRecordLength         : 11
-SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : yandex
-DkimAdvisory            : We couldn't find a DKIM record associated with your domain.
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
-DnsSec                  : Domain is DNSSEC signed.
-DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
+Name            : binsec.nl
+SpfRecord       : v=spf1 -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 11
+DmarcRecord     : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : dkim
+DkimAdvisory    : We couldn't find a DKIM record associated with your domain.
+MtaRecord       :
+MtaAdvisory     : The MTA-STS DNS record doesn't exist.
+DnsSec          : Domain is DNSSEC signed.
+DnsSecAdvisory  : Great! DNSSEC is enabled on your domain.
 
-Name                    : ing.nl
-SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9
-                           ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112.237.21 ip4:62.112.237.23 ip6:2a00:1558
-                          :2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.ing.net include:_spf.ing.nl -all
-SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configured and the policy i
-                          s sufficiently strict.
-SPFRecordLength         : 404
-SPFRecordDnsLookupCount : 4/10 (OK)
-DmarcRecord             : v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mailto:dmarc.feedback@ing.nl
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCpdtMaXjmYVG9zvSx74HUB
-                          b223TqMve8K1qBU/sW2I3ZijuP/37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;
-DkimSelector            : selector1
-DkimAdvisory            : DKIM-record found.
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
-DnsSec                  : Domain is DNSSEC signed.
-DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
+Name            : microsoft.com
+SpfRecord       : v=spf1 include:_spf-a.microsoft.com include:_spf-b.microsoft.com include:_spf-c.microsoft.com include:_spf-ssg-a.msft.net include:spf-a.ho
+                  tmail.com include:_spf1-meo.microsoft.com -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 184
+DmarcRecord     : v=DMARC1; p=reject; pct=100; rua=mailto:itex-rua@microsoft.com; ruf=mailto:itex-ruf@microsoft.com; fo=1
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCPkb8bu8RGWeJGk3hJrouZXIdZ+HTp/azRp8IUOHp5wKvPUAi/54PwuLscUjRk4Rh3hjIkMpKRfJJXPxWb
+                  rT7eMLric7f/S0h+qF4aqIiQqHFCDAYfMnN6V3Wbke2U5EGm0H/cAUYkaf2AtuHJ/rdY/EXaldAm00PgT9QQMez66QIDAQAB;
+DkimSelector    : selector2
+DkimAdvisory    : DKIM-record found.
+MtaRecord       : v=STSv1; id=20190225000000Z;
+MtaAdvisory     : The domain has the MTA-STS DNS record and file configured and protected against interception or tampering.
+DnsSec          : No DNSKEY records found.
+DnsSecAdvisory  : Enable DNSSEC on your domain. DNSSEC decreases the vulnerability to DNS attacks.
 ```
 
-Checks the SPF, DMARC, DKIM, Mta and DNSSEC configuration for the domains binsec.nl and ing.nl.
+Checks the SPF, DMARC, DKIM, Mta and DNSSEC configuration for the domains binsec.nl and microsoft.com.
 
 ### Example 3
-```powershell
-PS C:\> Invoke-spfDkimDmarc binsec.nl, ing.nl -IncludeDNSSEC -DkimSelector selector1 -server 1.1.1.1
+```
+PS C:\> Invoke-spfDkimDmarc binsec.nl, microsoft.com -IncludeDNSSEC -DkimSelector selector2 -server 1.1.1.1
 
-Name                    : binsec.nl
-SpfRecord               : "v=spf1 -all"
+Name            : binsec.nl
+SpfRecord       : v=spf1 -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 11
+DmarcRecord     : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : selector2
+DkimAdvisory    : No DKIM-record found for selector selector2._domainkey.binsec.nl
+MtaRecord       :
+MtaAdvisory     : The MTA-STS DNS record doesn't exist.
+DnsSec          : Domain is DNSSEC signed.
+DnsSecAdvisory  : Great! DNSSEC is enabled on your domain.
 
-SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
-SPFRecordLength         : 14
-SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : "v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;"
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : selector1
-DkimAdvisory            : No DKIM-record found for selector selector1._domainkey.binsec.nl
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
-DnsSec                  : Domain is DNSSEC signed.
-DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
-
-Name                    : ing.nl
-SpfRecord               : "v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.3
-                          4/31 ip4:78.31.119.9 ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112
-                          .237.21 ip4:62.112.237.23 ip6:2a00:1558:2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.ing.net include:_spf.ing.nl -all"
-
-SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configur
-                          ed and the policy is sufficiently strict.
-SPFRecordLength         : 407
-SPFRecordDnsLookupCount : 4/10 (OK)
-DmarcRecord             : "v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mailto:dmarc.feedback@ing.nl"
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              : "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyxRaOKkzswKa19QEg3fjhhg0Uhtq+stkjkdx1X7MelAGcB71tmxcJKH4iBlnltMLnyrWtfKrChTsrbF7cCp
-                          dtMaXjmYVG9zvSx74HUBb223TqMve8K1qBU/sW2I3ZijuP/37HacBcCmwXSQhe8+kkuGJ1Nq9eojmrdqxjB4QuTQIDAQAB;"
-DkimSelector            : selector1
-DkimAdvisory            : DKIM-record found.
-MtaRecord               : "v=spf1 -all"
-MtaAdvisory             : The MTA-STS id must be alphanumeric and no longer than 32 characters.
-DnsSec                  : Domain is DNSSEC signed.
-DnsSecAdvisory          : Great! DNSSEC is enabled on your domain.
+Name            : microsoft.com
+SpfRecord       : v=spf1 include:_spf-a.microsoft.com include:_spf-b.microsoft.com include:_spf-c.microsoft.com include:_spf-ssg-a.msft.net include:spf-a.ho
+                  tmail.com include:_spf1-meo.microsoft.com -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 184
+DmarcRecord     : v=DMARC1; p=reject; pct=100; rua=mailto:itex-rua@microsoft.com; ruf=mailto:itex-ruf@microsoft.com; fo=1
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      : v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCPkb8bu8RGWeJGk3hJrouZXIdZ+HTp/azRp8IUOHp5wKvPUAi/54PwuLscUjRk4Rh3hjIkMpKRfJJXPxWb
+                  rT7eMLric7f/S0h+qF4aqIiQqHFCDAYfMnN6V3Wbke2U5EGm0H/cAUYkaf2AtuHJ/rdY/EXaldAm00PgT9QQMez66QIDAQAB;
+DkimSelector    : selector2
+DkimAdvisory    : DKIM-record found.
+MtaRecord       : v=STSv1; id=20190225000000Z;
+MtaAdvisory     : The domain has the MTA-STS DNS record and file configured and protected against interception or tampering.
+DnsSec          : No DNSKEY records found.
+DnsSecAdvisory  : Enable DNSSEC on your domain. DNSSEC decreases the vulnerability to DNS attacks.
 ```
 
-Checks the SPF, DMARC, DKIM for dkimselector selector2, Mta and DNSSEC configuration for the domains binsec.nl and ing.nl using 1.1.1.1 as the DNS Server for the lookup.
+Checks the SPF, DMARC, DKIM for dkimselector selector2, Mta and DNSSEC configuration for the domains binsec.nl and microsoft.com using 1.1.1.1 as the DNS Server for the lookup.
 
 ### Example 3
-```powershell
+```
 Invoke-SpfDkimDmarc -File $env:USERPROFILE\Desktop\domains.txt -server 1.1.1.1 -DkimSelector zendesk1
 
-Name                    : binsec.nl
-SpfRecord               : v=spf1 -all
-SpfAdvisory             : An SPF-record is configured and the policy is sufficiently strict.
-SPFRecordLength         : 11
-SPFRecordDnsLookupCount : 0/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : zendesk1
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+Name            : binsec.nl
+SpfRecord       : v=spf1 -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 11
+DmarcRecord     : v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:rac3n92qqi@rua.powerdmarc.com; ruf=mailto:rac3n92qqi@ruf.powerdmarc.com; pct=100;
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : zendesk1
+MtaRecord       :
+MtaAdvisory     : The MTA-STS DNS record doesn't exist.
 
-Name                    : itsecuritymatters.nl
-SpfRecord               : v=spf1 include:_spf.protonmail.ch ~all
-SpfAdvisory             : An SPF-record is configured but the policy is not sufficiently strict.
-SPFRecordLength         : 38
-SPFRecordDnsLookupCount : 1/10 (OK)
-DmarcRecord             : v=DMARC1; p=reject; pct=100;
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : zendesk1
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+Name            : itsecuritymatters.nl
+SpfRecord       : v=spf1 include:spf.protection.outlook.com -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 46
+DmarcRecord     : v=DMARC1; p=reject; pct=100;
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : zendesk1
+MtaRecord       :
+MtaAdvisory     : The MTA-STS DNS record doesn't exist.
 
-Name                    : ing.nl
-SpfRecord               : v=spf1 ip4:80.248.34.0/24 ip4:195.248.87.0/24 ip4:85.112.22.247 ip4:74.63.141.251 ip4:83.149.86.160/27 ip4:83.149.121.128/26 ip4:80.79.192.34/31 ip4:78.31.119.9
-                           ip4:91.220.136.168 ip4:46.31.52.0/23 ip4:46.19.168.0/23 ip4:192.254.112.185 ip4:91.209.197.6 ip4:91.209.197.7 ip4:62.112.237.21 ip4:62.112.237.23 ip6:2a00:1558
-                          :2801:4::2:1 ip6:2a00:1558:2801:4::3:1 include:_spf.ing.net include:_spf.ing.nl -all
-SpfAdvisory             : Your SPF record has more than 255 characters in one string. This MUST not be done as explicitly defined in RFC4408. An SPF-record is configured and the policy i
-                          s sufficiently strict.
-SPFRecordLength         : 404
-SPFRecordDnsLookupCount : 4/10 (OK)
-DmarcRecord             : v=DMARC1;p=reject;rua=mailto:Global.Mail.DMARC@ing.com,mailto:ejdvezzq@ag.dmarcian-eu.com,mailto:dmarc.feedback@ing.nl
-DmarcAdvisory           : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
-DkimRecord              :
-DkimSelector            : zendesk1
-MtaRecord               : No MTA-STS DNS record found.
-MtaAdvisory             : The MTA-STS DNS record doesn't exist.
+Name            : microsoft.com
+SpfRecord       : v=spf1 include:_spf-a.microsoft.com include:_spf-b.microsoft.com include:_spf-c.microsoft.com include:_spf-ssg-a.msft.net include:spf-a.ho
+                  tmail.com include:_spf1-meo.microsoft.com -all
+SpfAdvisory     : An SPF-record is configured and the policy is sufficiently strict.
+SPFRecordLength : 184
+DmarcRecord     : v=DMARC1; p=reject; pct=100; rua=mailto:itex-rua@microsoft.com; ruf=mailto:itex-ruf@microsoft.com; fo=1
+DmarcAdvisory   : Domain has a DMARC record and your DMARC policy will prevent abuse of your domain by phishers and spammers.
+DkimRecord      :
+DkimSelector    : zendesk1
+MtaRecord       : v=STSv1; id=20190225000000Z;
+MtaAdvisory     : The domain has the MTA-STS DNS record and file configured and protected against interception or tampering.
 ```
 
-Checks the SPF, DMARC, DKIM for dkimselector zendesk1, Mta and DNSSEC configuration for the domains binsec.nl, itsecuritymatters.nl, ing.nl using 1.1.1.1 as the DNS Server for the lookup. The domains are listed in the file 'domains.txt'.
+Checks the SPF, DMARC, DKIM for dkimselector zendesk1, Mta and DNSSEC configuration for the domains binsec.nl, itsecuritymatters.nl, microsoft.com using 1.1.1.1 as the DNS Server for the lookup.
+The domains are listed in the file 'domains.txt'.
 
 ## PARAMETERS
 
@@ -209,21 +199,6 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -IncludeDNSSEC
-Include this switch to check for DNSSEC existance
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 5
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Name
 Specifies the domain for resolving the SPF, DKIM and DMARC-record.
 
@@ -254,18 +229,34 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-
 ### System.IO.FileInfo
-
 ## OUTPUTS
 
 ### System.Object
 ## NOTES
 
 ## RELATED LINKS
+
+[Invoke-SpfDkimDmarc is part of the 'DomainHealthChecker' module, available on the PowerShellGallery](https://www.powershellgallery.com/packages/DomainHealthChecker/)
+
+[Project site on Github](github.com/T13nn3s/Invoke-SpfDkimDmarc/)

--- a/public/CmdletHelp/Invoke-SpfDkimDmarc.md
+++ b/public/CmdletHelp/Invoke-SpfDkimDmarc.md
@@ -1,7 +1,7 @@
 ---
 external help file: DomainHealthChecker-help.xml
 Module Name: DomainHealthChecker
-online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md
+online version: https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-SpfDkimDmarc.md
 schema: 2.0.0
 ---
 

--- a/public/Get-BimiRecord.ps1
+++ b/public/Get-BimiRecord.ps1
@@ -1,0 +1,137 @@
+<#>
+HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-BIMI.md'
+#>
+
+# Load private functions
+Get-ChildItem -Path $PSScriptRoot\..\private\*.ps1 |
+ForEach-Object {
+    . $_.FullName
+}
+
+# Load public functions
+$PublicFolder = Join-Path -Path $PSScriptRoot -ChildPath 'public'
+if (Test-Path -Path $PublicFolder) {
+    Get-ChildItem -Path $PublicFolder -Filter "*.ps1" -File | ForEach-Object { . $_.FullName }
+}
+
+function Get-BimiRecord {
+    [CmdletBinding()]
+    param (
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            HelpMessage = "Specifies the domain for resolving the BIMI-record.",
+            Position = 1)]
+        [string[]]$Name,
+
+        [Parameter(Mandatory = $false,
+            HelpMessage = "DNS Server to use.",
+            Position = 2)]
+        [string]$Server
+    )
+
+    begin {
+        Write-Verbose "Starting $($MyInvocation.MyCommand)"
+        $PSBoundParameters | Out-String | Write-Verbose
+
+        # Determine OS platform
+        try {
+            Write-Verbose "Determining OS platform"
+            $OsPlatform = (Get-OsPlatform).Platform
+        }
+        catch {
+            Write-Verbose "Failed to determine OS platform, defaulting to Windows"
+            $OsPlatform = "Windows"
+        }
+
+        # Linux or macOS: Check if dnsutils is installed
+        if ($OsPlatform -eq "Linux" -or $OsPlatform -eq "macOS") {
+            Test-DnsUtilsInstalled
+        }
+        
+        if ($PSBoundParameters.ContainsKey('Server')) {
+            $SplatParameters = @{
+                'Server'      = $Server
+                'ErrorAction' = 'SilentlyContinue'
+            }
+        }
+        Else {
+            $SplatParameters = @{
+                'ErrorAction' = 'SilentlyContinue'
+            }
+        }
+
+        $BimiObject = New-Object System.Collections.Generic.List[System.Object]
+
+    } process {
+
+        foreach ($domain in $Name) {
+            Write-Verbose "Resolving BIMI record for domain: $domain"
+
+            # DMARC policy must be configured to at 'quarantine' or 'reject' for BIMI to function
+            # DMARC quarantine policies MUST NOT have a pct less than 'pct=100'.
+            # See: https://datatracker.ietf.org/doc/html/draft-brand-indicators-for-message-identification-12
+            try {
+
+                Write-Verbose "Checking DMARC record for domain: $domain"
+                $DmarcPolicy = Get-DMARCRecord -Name $domain @SplatParameters
+            }
+            Catch {
+                Write-Verbose "No DMARC record found for domain: $domain"
+                $null = $DmarcPolicy
+            } 
+            
+            if ($null -eq $DmarcPolicy) {
+                Write-Verbose "No DMARC record found for $domain"
+                $BimiAdvisory = "Does not have a DMARC record. To use BIMI, this domain must have a DMARC record with a policy of at least p=quarantine and pct=100."
+            }
+            else {
+                switch -Regex ($DmarcPolicy) {
+                    ('p=none') {
+                        $BimiAdvisory = "DMARC policy is set to p=none. BIMI requires a DMARC policy of at least p=quarantine to function."
+                    }
+                    ('p=quarantine') {
+                        $BimiAdvisory = "DMARC policy is set to p=quarantine. While BIMI can function with this policy, it is recommended to use p=reject for better protection."
+                    }
+                    ('p=reject') {
+                        $BimiAdvisory = "DMARC policy is set to p=reject. This is optimal for BIMI functionality."
+                    }
+                    ('pct=(\d{1,2}|100)') {
+                        $pctValue = [int]$Matches[1]
+                        if ($pctValue -lt 100) {
+                            $BimiAdvisory += "DMARC policy pct is set to less than 100%. BIMI requires a DMARC policy with pct=100 to function."
+                        }
+                    }
+                }
+
+            }
+
+            if ($OsPlatform -eq "Windows") {
+                $bimiRecord = Resolve-DnsName -Type TXT -Name "default._bimi.$($domain)" @SplatParameters | Select-Object -ExpandProperty strings
+            }
+            elseif ($OsPlatform -eq "macOS" -or $OsPlatform -eq "Linux") {
+                $bimiRecord = $(dig TXT "default._bimi.$($domain)" +short | Out-String).Trim()
+            }
+            elseif ($OsPlatform -eq "macOS" -or $OsPlatform -eq "Linux" -and $Server) {
+                $bimiRecord = $(dig TXT "default._bimi.$($domain)" +short NS $PSBoundParameters.Server | Out-String).Trim()
+            }
+
+            if ($null -eq $bimiRecord -or $bimiRecord -eq "") {
+                Write-Verbose "No BIMI record found for $domain"
+                $BimiAdvisory += " No BIMI record found for domain."
+                $BimiRecord = "No BiMI record found."
+            }
+
+            $BimiReturnValues = New-Object psobject
+            $BimiReturnValues | Add-Member NoteProperty "Name" $domain
+            $BimiReturnValues | Add-Member NoteProperty "BimiRecord" $BimiRecord
+            $BimiReturnValues | Add-Member NoteProperty "BimiAdvisory" $BimiAdvisory
+            $BimiObject.Add($BimiReturnValues)
+            $BimiReturnValues
+        }
+    } end {
+        Write-Verbose "Completed $($MyInvocation.MyCommand)"
+    }
+}
+Set-Alias -Name gbimi -Value Get-BimiRecord

--- a/public/Get-DKIMRecord.ps1
+++ b/public/Get-DKIMRecord.ps1
@@ -15,8 +15,8 @@ function Get-DKIMRecord {
             Mandatory = $True,
             ValueFromPipeline = $True,
             ValueFromPipelineByPropertyName = $True,
-            HelpMessage = "Specifies the domain for resolving the DKIM-record."
-        )][string[]]$Name,
+            HelpMessage = "Specifies the domain for resolving the DKIM-record.")]
+        [string[]]$Name,
 
         [Parameter(Mandatory = $False,
             HelpMessage = "Specify a custom DKIM selector.")]

--- a/public/Get-DKIMRecord.ps1
+++ b/public/Get-DKIMRecord.ps1
@@ -1,5 +1,5 @@
 <#>
-HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md'
+HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DKIMRecord.md'
 #>
 
 # Load private functions

--- a/public/Get-DKIMRecord.ps1
+++ b/public/Get-DKIMRecord.ps1
@@ -29,6 +29,9 @@ function Get-DKIMRecord {
 
     begin {
 
+        Write-Verbose "Starting $($MyInvocation.MyCommand)"
+        $PSBoundParameters | Out-String | Write-Verbose
+
         # Determine OS platform
         try {
             Write-Verbose "Determining OS platform"
@@ -43,9 +46,6 @@ function Get-DKIMRecord {
         if ($OsPlatform -eq "Linux" -or $OsPlatform -eq "macOS") {
             Test-DnsUtilsInstalled
         }
-
-        Write-Verbose "Starting $($MyInvocation.MyCommand)"
-        $PSBoundParameters | Out-String | Write-Verbose
         
         if ($PSBoundParameters.ContainsKey('Server')) {
             $SplatParameters = @{

--- a/public/Get-DMARCRecord.ps1
+++ b/public/Get-DMARCRecord.ps1
@@ -63,7 +63,7 @@ function Get-DMARCRecord {
 
             if ($OsPlatform -eq "Windows") {
                 Write-Verbose "Querying DMARC record for $domain"
-                $DMARC = Resolve-DnsName -Name "_dmarc.$($domain)" -Type TXT @SplatParameters | Select-Object -ExpandProperty strings -ErrorAction SilentlyContinue
+                $DMARC = Resolve-DnsName -Name "_dmarc.$($domain)" -Type TXT @SplatParameters | Select-Object -ExpandProperty strings
             }
             elseif ($OsPlatform -eq "macOS" -or $OsPlatform -eq "Linux") {
                 $DMARC = $(dig TXT "_dmarc.$($domain)" +short | Out-String).Trim()

--- a/public/Get-DMARCRecord.ps1
+++ b/public/Get-DMARCRecord.ps1
@@ -1,5 +1,5 @@
 <#>
-HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md'
+HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DMARCRecord.md'
 #>
 
 # Load private functions
@@ -63,7 +63,7 @@ function Get-DMARCRecord {
 
             if ($OsPlatform -eq "Windows") {
                 Write-Verbose "Querying DMARC record for $domain"
-                $DMARC = Resolve-DnsName -Name "_dmarc.$($domain)" -Type TXT @SplatParameters | Select-Object -ExpandProperty strings
+                $DMARC = Resolve-DnsName -Name "_dmarc.$($domain)" -Type TXT @SplatParameters | Select-Object -ExpandProperty strings -ErrorAction SilentlyContinue
             }
             elseif ($OsPlatform -eq "macOS" -or $OsPlatform -eq "Linux") {
                 $DMARC = $(dig TXT "_dmarc.$($domain)" +short | Out-String).Trim()

--- a/public/Get-DNSSEC.ps1
+++ b/public/Get-DNSSEC.ps1
@@ -15,8 +15,8 @@ function Get-DNSSec {
             Mandatory = $True,
             ValueFromPipeline = $True,
             ValueFromPipelineByPropertyName = $True,
-            HelpMessage = "Specifies the domain name for testing for DNSSEC existance."
-        )][string[]]$Name,
+            HelpMessage = "Specifies the domain name for testing for DNSSEC existance.")]
+        [string[]]$Name,
 
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.")]

--- a/public/Get-DNSSEC.ps1
+++ b/public/Get-DNSSEC.ps1
@@ -1,5 +1,5 @@
 <#>
-.HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DNSSec.md'
+.HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-DNSSec.md'
 #>
 
 # Load private functions

--- a/public/Get-SPFRecord.ps1
+++ b/public/Get-SPFRecord.ps1
@@ -15,8 +15,8 @@ function Get-SPFRecord {
             Mandatory = $True,
             ValueFromPipeline = $True,
             ValueFromPipelineByPropertyName = $True,
-            HelpMessage = "Enter one or more domain names to resolve their SPF records."
-        )][string[]]$Name,
+            HelpMessage = "Enter one or more domain names to resolve their SPF records.")]
+        [string[]]$Name,
 
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.")]

--- a/public/Get-SPFRecord.ps1
+++ b/public/Get-SPFRecord.ps1
@@ -1,5 +1,5 @@
 <#>
-.HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md'
+.HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Get-SPFRecord.md'
 #>
 
 # Load private functions

--- a/public/Invoke-MtaSts.ps1
+++ b/public/Invoke-MtaSts.ps1
@@ -15,8 +15,8 @@ function Invoke-MtaSts {
             Mandatory = $True,
             ValueFromPipeline = $True,
             ValueFromPipelineByPropertyName = $True,
-            HelpMessage = "Specifies the domain for resolving the MTA-STS record."
-        )][string[]]$Name,
+            HelpMessage = "Specifies the domain for resolving the MTA-STS record.")]
+        [string[]]$Name,
 
         [Parameter(Mandatory = $false,
             HelpMessage = "DNS Server to use.")]

--- a/public/Invoke-MtaSts.ps1
+++ b/public/Invoke-MtaSts.ps1
@@ -1,5 +1,5 @@
 <#>
-.HelpInfoURI 'https://github.com/T13nn3s/Show-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md'
+.HelpInfoURI 'https://github.com/T13nn3s/Invoke-SpfDkimDmarc/blob/main/public/CmdletHelp/Invoke-MtaSts.md'
 #>
 
 # Load private functions


### PR DESCRIPTION
### Added
- Added `-SkipUpdateCheck` on calling the module, to skip the update check against the PowerShellgallery
- Added `Get-BIMIRecord` check, this function resolves and validates BIMI (Brand Indicators for Message Identification) records for one or more domains.

### Changed
- Renamed `Update-ModuleVersion` to `Update-DomainHealthChecker` to better reflect the true mean of this function.
- Updated README/help docs

### Removed
- Removed the `-IncludeDNSSEC` parameter, DNSSEC is now default queried